### PR TITLE
make ganglia optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This app displays the current system status of available system clusters.
 2. Install the app for a production environment.
 
     ```bash
-    RAILS_ENV=production scl enable git19 rh-ruby22 nodejs010 -- bin/setup
+    RAILS_ENV=production scl enable git19 rh-ruby24 rh-nodejs6  -- bin/setup
     ```
 
 ### Deployment at OSC

--- a/app.rb
+++ b/app.rb
@@ -7,9 +7,13 @@ Dir[File.dirname(__FILE__) + "/lib/*.rb"].each {|file| require_relative file }
 
 # more details see ood_appkit lib/ood_appkit/configuration.rb
 begin
-  CLUSTERS = OodCore::Clusters.new(OodCore::Clusters.load_file(ENV['OOD_CLUSTERS'] || '/etc/ood/config/clusters.d').select(&:job_allow?)
+  GANGLIA_CLUSTERS = OodCore::Clusters.new(OodCore::Clusters.load_file(ENV['OOD_CLUSTERS'] || '/etc/ood/config/clusters.d').select(&:job_allow?)
             .select { |c| c.custom_config[:moab] }
             .select { |c| c.custom_config[:ganglia] }
+            .reject { |c| c.metadata.hidden }
+          )
+   CLUSTERS = OodCore::Clusters.new(OodCore::Clusters.load_file(ENV['OOD_CLUSTERS'] || '/etc/ood/config/clusters.d').select(&:job_allow?)
+            .select { |c| c.custom_config[:moab] }
             .reject { |c| c.metadata.hidden }
           )
 rescue OodCore::ConfigurationNotFound
@@ -42,7 +46,7 @@ get '/clusters/:id/:time/:type' do
   @id=params[:id].to_sym
   graph_time.keys.include?(params[:time].to_sym) ? @time=params[:time].to_sym : @time=:hour
   graph_types.keys.include?(params[:type].to_sym) ? @type=params[:type].to_sym : @type=:report_moab_nodes
-  cluster = CLUSTERS[@id]
+  cluster = GANGLIA_CLUSTERS[@id]
   if cluster.nil?
     raise Sinatra::NotFound
   else

--- a/views/_node_status.erb
+++ b/views/_node_status.erb
@@ -1,37 +1,31 @@
-<!-- node status panel -->
-<a href = "<%= url("/clusters/#{showqer.cluster_id}/hour/report_moab_nodes") if clickable %>">
-    <div class="panel panel-default bs-callout bs-callout-info text-center <%= clickable ? 'panel-clickable' : 'panel-unclickable' %>">
-        <h4><strong><%= showqer.cluster_title %> Cluster Status</strong></h4>
-        <!-- node status progressbar -->
-        <div><%= showqer.nodes_used %> of <%= showqer.nodes_avail %> Nodes Active</div>
-        <div class="progress">
-            <div class="progress-bar" role="progressbar" style="width:<%= showqer.nodes_percent.round(2) %>%">
-                <%=(showqer.nodes_percent).round(2) %>%
-            </div>
-        </div>
-        <div><%= showqer.procs_used %> of <%= showqer.procs_avail %> Processors Active</div>
-        <div class="progress">
-            <div class="progress-bar" role="progressbar" style="width:<%= showqer.procs_percent.round(2) %>%">
-                <%= (showqer.procs_percent).round(2) %>%
-            </div>
-        </div>
-        <hr>
-        <div><h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4></div>
-        
-        <div class="row">
-          <div class="col-sm-2 col-xs-3">Running</div>
-          <div class="progress progress-custom">
-              <div class="progress-bar col-sm-10 col-xs-9" role="progressbar" style="width:<%= showqer.active_percent*0.89 %>%"></div>
-              <div><%= showqer.active_jobs %></div>
-           </div>
-        </div>
-        
-        <div class="row">
-          <div class="col-sm-2 col-xs-3">Queued</div>
-          <div class="progress progress-custom">
-             <div class="progress-bar progress-bar-info col-sm-10 col-xs-9" role="progressbar" style="width:<%= showqer.eligible_percent*0.89 %>%"></div>
-             <div><%= showqer.eligible_jobs %></div>
-          </div>
-        </div>
+<!-- node status progressbar -->
+<div><%= showqer.nodes_used %> of <%= showqer.nodes_avail %> Nodes Active</div>
+<div class="progress">
+    <div class="progress-bar" role="progressbar" style="width:<%= showqer.nodes_percent.round(2) %>%">
+        <%=(showqer.nodes_percent).round(2) %>%
     </div>
-</a>
+</div>
+<div><%= showqer.procs_used %> of <%= showqer.procs_avail %> Processors Active</div>
+<div class="progress">
+    <div class="progress-bar" role="progressbar" style="width:<%= showqer.procs_percent.round(2) %>%">
+        <%= (showqer.procs_percent).round(2) %>%
+    </div>
+</div>
+<hr>
+<div><h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4></div>
+
+<div class="row">
+  <div class="col-sm-2 col-xs-3">Running</div>
+  <div class="progress progress-custom">
+      <div class="progress-bar col-sm-10 col-xs-9" role="progressbar" style="width:<%= showqer.active_percent*0.89 %>%"></div>
+      <div><%= showqer.active_jobs %></div>
+   </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-2 col-xs-3">Queued</div>
+  <div class="progress progress-custom">
+     <div class="progress-bar progress-bar-info col-sm-10 col-xs-9" role="progressbar" style="width:<%= showqer.eligible_percent*0.89 %>%"></div>
+     <div><%= showqer.eligible_jobs %></div>
+  </div>
+</div>

--- a/views/_node_status.erb
+++ b/views/_node_status.erb
@@ -1,31 +1,37 @@
-<!-- node status progressbar -->
-<div><%= showqer.nodes_used %> of <%= showqer.nodes_avail %> Nodes Active</div>
-<div class="progress">
-    <div class="progress-bar" role="progressbar" style="width:<%= showqer.nodes_percent.round(2) %>%">
-        <%=(showqer.nodes_percent).round(2) %>%
+<!-- node status panel -->
+<a href = "<%= url("/clusters/#{showqer.cluster_id}/hour/report_moab_nodes") %>">
+    <div class="panel panel-default bs-callout bs-callout-info text-center <%= clickable ? 'panel-clickable' : 'panel-unclickable' %>">
+        <h4><strong><%= showqer.cluster_title %> Cluster Status</strong></h4>
+        <!-- node status progressbar -->
+        <div><%= showqer.nodes_used %> of <%= showqer.nodes_avail %> Nodes Active</div>
+        <div class="progress">
+            <div class="progress-bar" role="progressbar" style="width:<%= showqer.nodes_percent.round(2) %>%">
+                <%=(showqer.nodes_percent).round(2) %>%
+            </div>
+        </div>
+        <div><%= showqer.procs_used %> of <%= showqer.procs_avail %> Processors Active</div>
+        <div class="progress">
+            <div class="progress-bar" role="progressbar" style="width:<%= showqer.procs_percent.round(2) %>%">
+                <%= (showqer.procs_percent).round(2) %>%
+            </div>
+        </div>
+        <hr>
+        <div><h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4></div>
+        
+        <div class="row">
+          <div class="col-sm-2 col-xs-3">Running</div>
+          <div class="progress progress-custom">
+              <div class="progress-bar col-sm-10 col-xs-9" role="progressbar" style="width:<%= showqer.active_percent*0.89 %>%"></div>
+              <div><%= showqer.active_jobs %></div>
+           </div>
+        </div>
+        
+        <div class="row">
+          <div class="col-sm-2 col-xs-3">Queued</div>
+          <div class="progress progress-custom">
+             <div class="progress-bar progress-bar-info col-sm-10 col-xs-9" role="progressbar" style="width:<%= showqer.eligible_percent*0.89 %>%"></div>
+             <div><%= showqer.eligible_jobs %></div>
+          </div>
+        </div>
     </div>
-</div>
-<div><%= showqer.procs_used %> of <%= showqer.procs_avail %> Processors Active</div>
-<div class="progress">
-    <div class="progress-bar" role="progressbar" style="width:<%= showqer.procs_percent.round(2) %>%">
-        <%= (showqer.procs_percent).round(2) %>%
-    </div>
-</div>
-<hr>
-<div><h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4></div>
-
-<div class="row">
-  <div class="col-sm-2 col-xs-3">Running</div>
-  <div class="progress progress-custom">
-      <div class="progress-bar col-sm-10 col-xs-9" role="progressbar" style="width:<%= showqer.active_percent*0.89 %>%"></div>
-      <div><%= showqer.active_jobs %></div>
-   </div>
-</div>
-
-<div class="row">
-  <div class="col-sm-2 col-xs-3">Queued</div>
-  <div class="progress progress-custom">
-     <div class="progress-bar progress-bar-info col-sm-10 col-xs-9" role="progressbar" style="width:<%= showqer.eligible_percent*0.89 %>%"></div>
-     <div><%= showqer.eligible_jobs %></div>
-  </div>
-</div>
+</a>

--- a/views/_node_status.erb
+++ b/views/_node_status.erb
@@ -1,5 +1,5 @@
 <!-- node status panel -->
-<a href = "<%= url("/clusters/#{showqer.cluster_id}/hour/report_moab_nodes") %>">
+<a href = "<%= url("/clusters/#{showqer.cluster_id}/hour/report_moab_nodes") if clickable %>">
     <div class="panel panel-default bs-callout bs-callout-info text-center <%= clickable ? 'panel-clickable' : 'panel-unclickable' %>">
         <h4><strong><%= showqer.cluster_title %> Cluster Status</strong></h4>
         <!-- node status progressbar -->

--- a/views/index.erb
+++ b/views/index.erb
@@ -2,19 +2,7 @@
 <!-- node status on /clusters page -->
 <% @clusters.each_with_index do |cluster, index | %>   
       <div class="<%= 'col-sm-offset-3' if index == @clusters.count - 1 && @clusters.count.odd? %> col-sm-6 col-xs-12">
-          <% if GANGLIA_CLUSTERS[cluster.cluster_id].nil? %>
-            <div class="panel panel-default bs-callout bs-callout-info text-center panel-unclickable">
-              <h4><strong><%= cluster.cluster_title %> Cluster Status</strong></h4>
-              <%= erb :_node_status, :locals => { :showqer => cluster } %>
-            </div>
-	      <% else %>
-          <a href = "<%= url("/clusters/#{cluster.cluster_id}/hour/report_moab_nodes") %>">
-            <div class="panel panel-default bs-callout bs-callout-info text-center panel-clickable">
-              <h4><strong><%= cluster.cluster_title %> Cluster Status</strong></h4>
-              <%= erb :_node_status, :locals => { :showqer => cluster } %>
-            </div>
-	      </a>
-	      <% end %>
+          <%= erb :_node_status, :locals => { :showqer => cluster, :clickable => !GANGLIA_CLUSTERS[cluster.cluster_id].nil? } %>
       </div>
 <% end %>
 </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -2,12 +2,19 @@
 <!-- node status on /clusters page -->
 <% @clusters.each_with_index do |cluster, index | %>   
       <div class="<%= 'col-sm-offset-3' if index == @clusters.count - 1 && @clusters.count.odd? %> col-sm-6 col-xs-12">
+          <% if GANGLIA_CLUSTERS[cluster.cluster_id].nil? %>
+            <div class="panel panel-default bs-callout bs-callout-info text-center panel-unclickable">
+              <h4><strong><%= cluster.cluster_title %> Cluster Status</strong></h4>
+              <%= erb :_node_status, :locals => { :showqer => cluster } %>
+            </div>
+	      <% else %>
           <a href = "<%= url("/clusters/#{cluster.cluster_id}/hour/report_moab_nodes") %>">
             <div class="panel panel-default bs-callout bs-callout-info text-center panel-clickable">
               <h4><strong><%= cluster.cluster_title %> Cluster Status</strong></h4>
               <%= erb :_node_status, :locals => { :showqer => cluster } %>
             </div>
 	      </a>
+	      <% end %>
       </div>
 <% end %>
 </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -6,7 +6,7 @@
         <a class="<%= GANGLIA_CLUSTERS[cluster.cluster_id].nil? ? "unclickable" : "clickable" %>" href="<%= url("/clusters/#{cluster.cluster_id}/hour/report_moab_nodes") %>">
             <div class="panel panel-default bs-callout bs-callout-info text-center">
                 <h4><strong><%= cluster.cluster_title %> Cluster Status</strong></h4>
-                <%= erb :_node_status, :locals => { :showqer => cluster} %>
+                <%= erb :_node_status, :locals => { :showqer => cluster } %>
             </div>
         </a>
     </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,9 +1,15 @@
 <div class="row">
 <!-- node status on /clusters page -->
 <% @clusters.each_with_index do |cluster, index | %>   
-      <div class="<%= 'col-sm-offset-3' if index == @clusters.count - 1 && @clusters.count.odd? %> col-sm-6 col-xs-12">
-          <%= erb :_node_status, :locals => { :showqer => cluster, :clickable => !GANGLIA_CLUSTERS[cluster.cluster_id].nil? } %>
-      </div>
+    <div class="<%= 'col-sm-offset-3' if index == @clusters.count - 1 && @clusters.count.odd? %> col-sm-6 col-xs-12">
+        <!-- node status panel -->
+        <a class="<%= GANGLIA_CLUSTERS[cluster.cluster_id].nil? ? "unclickable" : "clickable" %>" href="<%= url("/clusters/#{cluster.cluster_id}/hour/report_moab_nodes") %>">
+            <div class="panel panel-default bs-callout bs-callout-info text-center">
+                <h4><strong><%= cluster.cluster_title %> Cluster Status</strong></h4>
+                <%= erb :_node_status, :locals => { :showqer => cluster} %>
+            </div>
+        </a>
+    </div>
 <% end %>
 </div>
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -46,16 +46,18 @@
     .img-responsive {
       min-width: 100%;
     }
-    .panel-clickable:hover {
+    .clickable .panel:hover {
       background-color: #c1cdf0;
       border-color: #6c75f0;
     }
-    .panel-clickable.active {
+    .clickable .panel.active {
       background-color: #6c75f0;
       border-color: #6c75f0;
     }
-    .panel-unclickable {
+    .unclickable {
       cursor: default;
+      text-decoration: none !important;
+      pointer-events: none;
     }
     a:-webkit-any-link {
       text-decoration: none !important;

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -22,7 +22,7 @@
       /* Internet Explorer 5.5+ */
     }
     /* Base styles */
-    div .bs-callout {
+    div a .bs-callout {
       margin: 20px 0;
       padding: 15px 30px 15px 15px;
       border-left: 5px solid #eee;

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -22,7 +22,7 @@
       /* Internet Explorer 5.5+ */
     }
     /* Base styles */
-    div a .bs-callout {
+    div .bs-callout {
       margin: 20px 0;
       padding: 15px 30px 15px 15px;
       border-left: 5px solid #eee;
@@ -39,7 +39,7 @@
     .bs-callout code, .bs-callout .highlight {
       background-color: #fff;
     }
-    div a .bs-callout-info {
+    div .bs-callout-info {
       background-color: #f0f7fd;
       border-color: #d0e3f0;
     }
@@ -53,6 +53,9 @@
     .panel-clickable.active {
       background-color: #6c75f0;
       border-color: #6c75f0;
+    }
+    .panel-unclickable {
+      cursor: default;
     }
     a:-webkit-any-link {
       text-decoration: none !important;
@@ -107,7 +110,7 @@
       <!-- Collect the nav links, forms, and other content for toggling -->
       <div class="collapse navbar-collapse navbar-responsive-collapse">
         <ul class="nav navbar-nav">
-          <% CLUSTERS.each do |cluster| %>
+          <% GANGLIA_CLUSTERS.each do |cluster| %>
               <li class="<%= 'active' if @ganglia && @ganglia.server_id == cluster.id %>">
                 <a href="<%= url("/clusters/#{cluster.id}/hour/report_moab_nodes") %>"><span><i class="fa fa-chart-area"></i></span>  <%=cluster.metadata.title %> Cluster</a>
               </li>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -39,7 +39,7 @@
     .bs-callout code, .bs-callout .highlight {
       background-color: #fff;
     }
-    div .bs-callout-info {
+    div a .bs-callout-info {
       background-color: #f0f7fd;
       border-color: #d0e3f0;
     }


### PR DESCRIPTION
Changes:
- Both clusters with and without Ganglia are shown on the main page.
- Clusters without Ganglia is not clickable on the main page.
- Clusters without Ganglia is hidden in the navigation bar.

fixes #65 