### PR TITLE
Add support for Slurm clusters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ffi (1.12.2)
-    minitest (5.14.0)
+    ffi (1.13.1)
+    minitest (5.14.1)
     mocha (1.11.2)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    ood_core (0.11.1)
+    ood_core (0.13.0)
       ffi (~> 1.9, >= 1.9.6)
       ood_support (~> 0.0.2)
     ood_support (0.0.3)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-protection (2.0.8.1)
       rack
     rake (13.0.1)

--- a/app.rb
+++ b/app.rb
@@ -16,9 +16,8 @@ require_relative 'lib/slurm_squeue_client'
 begin
   CLUSTERS = OodCore::Clusters.new(OodCore::Clusters.load_file(ENV['OOD_CLUSTERS'] || '/etc/ood/config/clusters.d').select(&:job_allow?)
     .select { |c| c.custom_config[:ganglia] || c.custom_config[:grafana] }
+    .select { |c| c.custom_config[:moab] || c.job_config[:adapter] == "slurm" }
     .reject { |c| c.metadata.hidden }
-    #.select { |c| c.custom_config[:moab] }
-    #.select { |c| c.custom_config[:ganglia] || c.custom_config[:grafana] }
   )
 rescue OodCore::ConfigurationNotFound
   CLUSTERS = OodCore::Clusters.new([])

--- a/lib/gpu_cluster_status_slurm.rb
+++ b/lib/gpu_cluster_status_slurm.rb
@@ -1,0 +1,150 @@
+# Utility class for getting numerical data regarding GPU usage in the set of clusters that allow job submission using Slurm
+#
+
+class GPUClusterStatusSlurm
+
+  attr_reader :gpus_unallocated, :total_gpus, :full_nodes_available, :queued_jobs_requesting_gpus, :error_message
+
+  # Set the object to the server.
+  #
+  # @param cluster [OodCore::Clusters]
+  #
+  # @return [GPUClusterStatus]
+  def initialize(cluster)
+    @oodClustersAdapter = nil
+    @server = "/usr/bin"
+    @cluster_id = cluster.id
+    @cluster_title = cluster.metadata.title || cluster.id.titleize
+   self
+  end
+
+  def setup
+    #calc_total_gpus
+    #calc_gpus_unallocated
+    #calc_full_nodes_avail
+    #calc_queued_jobs_requesting_GPUs
+    self
+  rescue => e
+    GPUClusterStatusNotAvailable.new(@cluster_id, @cluster_title, e)
+  end
+
+  # @return [Pathname] pbs bin pathname
+  def pbs_bin
+    Pathname.new(@server['bin'].to_s)
+  end
+
+  # Defines a method for writing a pbsnodes command line to a terminal.
+  #
+  # @param cluster_server [String]
+  def pbsnodes(cluster_server)
+    #cmd = pbs_bin.join("pbsnodes").to_s
+    args = ["-s", cluster_server, ":gpu"]
+    o, e, s = Open3.capture3(cmd, *args)
+    s.success? ? o : raise(CommandFailed, e)
+  rescue Errno::ENOENT => e
+     raise InvalidCommand, e.message
+  end
+
+  # @return [String] Information regarding cluster nodes
+  def nodes_info
+    #pbsnodes(@cluster_title.downcase + "-batch.ten.osc.edu")
+  end
+
+  # Calculate total number of GPUs on a cluster
+  # @return [Integer] total number of gpus in a cluster
+  def calc_total_gpus
+    @total_gpus = 0
+    #if @cluster_title.eql?("Ruby")
+    #   # For the Ruby cluster, pbsnodes takes into account two debug nodes with two GPUs along with the other Ruby GPU nodes. The debug nodes will not be considered in the total GPUs and unallocated GPUs calculation, as they cannot be allocated as part of a regular job request with other GPU nodes. Here np = 20 is the number of processors for a GPU node rather than a debug node (np = 16) in a Ruby cluster.
+    #   @total_gpus = nodes_info.scan(/np = 20/).size
+    #  else
+    #   @total_gpus = nodes_info.lines("\n\n").size
+    #end
+  end
+
+  # Calculate number of unallocated GPUs with atleast one core available
+  # @return [Integer] the number of unallocated GPUs
+  def calc_gpus_unallocated
+    @gpus_unallocated = 0
+    #if @cluster_title.eql?('Owens')
+    #  @gpus_unallocated = nodes_info.lines("\n\n").select { |node|
+    #    !node.include?("dedicated_threads = 28") && node.include?("Unallocated") }.size
+    # elsif @cluster_title.eql?('Pitzer')
+    #  @gpus_unallocated = nodes_info.lines("\n\n").select { |node| !node.include?("dedicated_threads = 40") }.to_s.scan(/gpu_state=Unallocated/).size
+    # else @cluster_title.eql?('Ruby')
+    #  # See line 62. Excluding the two debug nodes from the calculation.
+    #  @gpus_unallocated = nodes_info.lines("\n\n").select { |node| node.include?("Unallocated") && !node.include?("dedicated_threads = 20") && node.include?("np = 20") }.size
+    #  @oodClustersAdapter.info_all_each { |job| p job}
+    #end
+  end
+
+  # Calculate number of full nodes (nodes with all cores free) available that contain one or more GPUs available
+  # @return [Integer] the number of full nodes available
+  def calc_full_nodes_avail
+    @full_nodes_available = 0
+    #if @cluster_title.eql?("Ruby")
+    #  # See line 62
+    #@full_nodes_available = nodes_info.lines("\n\n").select { |node| node.include?("dedicated_threads = 0") && node.include?("np = 20") && node.include?("gpu_state=Unallocated")}.size
+    #else
+    #@full_nodes_available = nodes_info.lines("\n\n").select { |node| node.include?("dedicated_threads = 0") && node.include?("gpu_state=Unallocated") }.size
+    #end
+  end
+
+  # Calculates number of jobs that have requested one or more GPUs that are currently queued
+  # @return [Integer] the number of queued jobs requesting GPUs
+  def calc_queued_jobs_requesting_GPUs
+    @queued_jobs_requesting_gpus = 0
+    #@queued_jobs_requesting_gpus = 0
+    #@oodClustersAdapter.info_all_each { |job| queued_jobs_requesting_gpus_counter(job) }
+    #@queued_jobs_requesting_gpus
+  end
+
+  # Checks to see whether a job is queued and requesting a gpu
+  #
+  # @param job [OodCore::Job::Info]
+  # @return true if job requested a gpu and is queued otherwise false
+  def is_job_requesting_gpus_and_queued(job)
+    false
+    # job.status.queued? && job.native[:Resource_List][:nodes].include?("gpus")
+  end
+
+  # Return the allocated GPUs as percent of available GPUs
+  #
+  # @return [Float] The percentage GPUs used
+  def gpus_percent
+    ((0.10).to_f) * 100
+    #((total_gpus - full_nodes_available).to_f / total_gpus.to_f) * 100
+  end
+
+  # Return the percentage of queued jobs requesting gpus
+  #
+  # @return [Float] The percentage GPUs queued
+  def percent_of_queued_jobs_requesting_gpus(available_jobs)
+    ((0.15).to_f) * 100
+    #(queued_jobs_requesting_gpus.to_f / available_jobs) * 100
+  end
+
+  # Return the percentage of queued jobs not requesting gpus
+  #
+  # @return [Float] The percentage
+  def percent_of_queued_jobs_not_requesting_gpus(available_jobs, eligible_jobs)
+    #@queued_jobs_requesting_no_gpus = (eligible_jobs - queued_jobs_requesting_gpus).abs()
+    #(@queued_jobs_requesting_no_gpus.to_f / available_jobs) * 100
+  end
+
+  private
+
+    attr_accessor :oodClustersAdapter
+
+    # Helper Methods
+
+    # Helper method for counting the number of queued gpus and jobs requesting gpus
+    #
+    # @param job [OodCore::Job::Info]
+    def queued_jobs_requesting_gpus_counter(job)
+      if is_job_requesting_gpus_and_queued(job)
+        #@queued_jobs_requesting_gpus += 1
+        return 0
+      end
+    end
+end

--- a/lib/moab_showq_client.rb
+++ b/lib/moab_showq_client.rb
@@ -18,7 +18,12 @@ class MoabShowqClient
     end
     @cluster_id = cluster.id
     @cluster_title = cluster.metadata.title || cluster.id.titleize
+    @job_scheduler = cluster.job_config[:adapter]
     self
+  end
+
+  def job_scheduler_name
+    return @job_scheduler
   end
 
   def setup

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -1,0 +1,200 @@
+class SlurmSqueueClient
+
+  attr_reader :active_jobs, :eligible_jobs, :blocked_jobs, :procs_used, :procs_avail, :nodes_used, :nodes_avail, :error_message, :dashboard_url, :cluster_id, :cluster_title, :friendly_error_message
+
+  # Set the object to the server.
+  #
+  # @param [OodAppkit::Cluster]
+  #
+  # @return [SlurmSqueueClient] self
+  def initialize(cluster)
+    @server = cluster.job_config[:bin]
+  
+    if cluster.custom_config.key?(:grafana)
+      @dashboard_url = "/clusters/#{cluster.id}/grafana"
+    end
+  
+    @cluster_id = cluster.id
+    @cluster_title = cluster.metadata.title || cluster.id.titleize
+    @job_scheduler = cluster.job_config[:adapter]
+
+    self
+  end
+
+  # Return job scheduler type from config
+  def job_scheduler_name
+    @job_scheduler
+  end
+
+  # Get pending jobs
+  def squeue_jobs_pending
+    cmd = '/usr/bin/squeue'
+    args = ["-h", "--all", "--states=PENDING"]
+  
+    o, e, s = Open3.capture3({}, cmd, *args)
+    
+    s.success? ? o : raise(CommandFailed, e)
+  end
+
+  # Get running jobs
+  def squeue_jobs_running
+    cmd = '/usr/bin/squeue'
+    args = ["-h", "--all", "--states=RUNNING"]
+  
+    o, e, s = Open3.capture3({}, cmd, *args)
+    
+    s.success? ? o : raise(CommandFailed, e)
+  end
+
+  # Get cluster info (node count, core count, etc.)
+  def sinfo
+    cmd = '/usr/bin/sinfo'
+    args = ["-s", "-h", "-o=\"%C/%A\""]
+  
+    o, e, s = Open3.capture3({}, cmd, *args)
+    
+    s.success? ? o : raise(CommandFailed, e)
+  end
+  
+  def cluster_info
+    sinfo_out               = sinfo.split('/')
+    running_jobs            = 0
+    pending_jobs            = 0
+    squeue_jobs_running.split("\n").each{ |line| running_jobs += 1 }
+    squeue_jobs_pending.split("\n").each{ |line| pending_jobs += 1 }
+
+    sinfo_out.each{ |line|
+      # Strip extra chars returned by Slurm
+      line.gsub!('"', '')
+      line.gsub!('=', '')
+    }
+
+    {
+      procs_used:     sinfo_out[0].to_i,
+      procs_avail:    sinfo_out[1].to_i,
+      nodes_used:     sinfo_out[4].to_i,
+      nodes_idle:     sinfo_out[5].to_i,
+      available_jobs: running_jobs.to_i,
+      pending_jobs:   pending_jobs.to_i,
+    }
+  end
+
+  def setup
+    self.active_jobs   = cluster_info[:available_jobs]
+    self.eligible_jobs = cluster_info[:pending_jobs]
+    self.blocked_jobs  = cluster_info[:blocked_jobs]
+
+    self.procs_used    = cluster_info[:procs_used]
+    self.procs_avail   = cluster_info[:procs_avail]
+    self.nodes_used    = cluster_info[:nodes_used]
+    self.nodes_avail   = cluster_info[:nodes_idle]
+
+    self
+  rescue => e
+    # TODO Add logging and a flash message that was removed from the controller
+    # SlurmSqueueClientNotAvailable.new(cluster_id, cluster_title, e)
+  end
+  
+  # Return moab lib pathname
+  def moab_lib
+    Pathname.new(@server['lib'].to_s)
+  end
+  
+  # Return moab bin pathname
+  def moab_bin
+    Pathname.new(@server['bin'].to_s)
+  end
+  
+  # Return moab home directory pathname
+  def moab_home 
+    Pathname.new(@server['homedir'].to_s)
+  end
+
+  # Return total CPU cores 
+  def total_cpu_cores
+    cmd = "sinfo"
+    # $ sinfo -s -h -o="%C"
+    #   allocated/idle/other/total
+    #   =960/18144/192/19296
+    # 0 1 2 3
+    args = ["-s", "-h", "-o=\"%C\"\\"]
+    env = {}.merge(env.to_h)
+    o, e, s = Open3.capture3(env, cmd, *args)
+    raise(CommandFailed, e) unless s.success?
+
+    lines = o.split("/")
+    lines[3].to_i
+  end
+
+  # Return total CPU cores 
+  def used_cpu_cores
+    cmd = "sinfo"
+    # $ sinfo -s -h -o="%C"
+    #   allocated/idle/other/total
+    #   =960/18144/192/19296
+    # 0 1 2 3
+    args = ["-s", "-h", "-o=\"%C\"\\"]
+    env = {}.merge(env.to_h)
+    o, e, s = Open3.capture3(env, cmd, *args)
+    raise(CommandFailed, e) unless s.success?
+
+    lines = o.split("/")
+    lines.each{ |line|
+      # Strip extra chars returned by Slurm
+      line.gsub!('"', '')
+      line.gsub!('=', '')
+    }
+    lines[0].to_i
+  end
+
+  # Return the active jobs as percent of available jobs
+  #
+  # @return [Float] The percentage active as float
+  def active_percent
+    (active_jobs.to_f / available_jobs.to_f) * 100
+  end
+
+  # Return the eligible jobs as percent of available jobs
+  #
+  # @return [Float] The percentage eligible as float
+  def eligible_percent
+    (eligible_jobs.to_f / available_jobs.to_f) * 100
+  end
+
+  # Total active + eligible
+  #
+  # @return [Integer] the total number of active/eligible jobs
+  def available_jobs
+    active_jobs + eligible_jobs
+  end
+
+  # Return the processor usage as percent
+  #
+  # @return [Float] The number of processors used as float
+  def procs_percent
+    (procs_used.to_f / procs_avail.to_f) * 100
+  end
+
+  # Return the node usage as percent
+  #
+  # @return [Float] The number of nodes used as float
+  def nodes_percent
+    (nodes_used.to_f / nodes_avail.to_f) * 100
+  end
+  
+  # Return cluster title + error message
+  #
+  # @return nil or constructed error message
+  def friendly_error_message
+    error_message.nil? ? nil : "#{cluster_title} Cluster: #{error_message}"
+  end
+
+  private
+
+    attr_writer :active_jobs, :eligible_jobs, :blocked_jobs, :procs_used, :procs_avail, :nodes_used, :nodes_avail,:error_message, :cluster_id, :cluster_title
+
+    # assign 0 if the input is nil or empty
+    def assign(match_string)
+      !match_string.blank? ? match_string : 0
+    end
+end

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -94,58 +94,6 @@ class SlurmSqueueClient
     # TODO Add logging and a flash message that was removed from the controller
     # SlurmSqueueClientNotAvailable.new(cluster_id, cluster_title, e)
   end
-  
-  # Return moab lib pathname
-  def moab_lib
-    Pathname.new(@server['lib'].to_s)
-  end
-  
-  # Return moab bin pathname
-  def moab_bin
-    Pathname.new(@server['bin'].to_s)
-  end
-  
-  # Return moab home directory pathname
-  def moab_home 
-    Pathname.new(@server['homedir'].to_s)
-  end
-
-  # Return total CPU cores 
-  def total_cpu_cores
-    cmd = "sinfo"
-    # $ sinfo -s -h -o="%C"
-    #   allocated/idle/other/total
-    #   =960/18144/192/19296
-    # 0 1 2 3
-    args = ["-s", "-h", "-o=\"%C\"\\"]
-    env = {}.merge(env.to_h)
-    o, e, s = Open3.capture3(env, cmd, *args)
-    raise(CommandFailed, e) unless s.success?
-
-    lines = o.split("/")
-    lines[3].to_i
-  end
-
-  # Return total CPU cores 
-  def used_cpu_cores
-    cmd = "sinfo"
-    # $ sinfo -s -h -o="%C"
-    #   allocated/idle/other/total
-    #   =960/18144/192/19296
-    # 0 1 2 3
-    args = ["-s", "-h", "-o=\"%C\"\\"]
-    env = {}.merge(env.to_h)
-    o, e, s = Open3.capture3(env, cmd, *args)
-    raise(CommandFailed, e) unless s.success?
-
-    lines = o.split("/")
-    lines.each{ |line|
-      # Strip extra chars returned by Slurm
-      line.gsub!('"', '')
-      line.gsub!('=', '')
-    }
-    lines[0].to_i
-  end
 
   # Return the active jobs as percent of available jobs
   #

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -28,32 +28,38 @@ class SlurmSqueueClient
 
   # Get pending jobs
   def squeue_jobs_pending
+    return @squeue_jobs_pending if defined?(@squeue_jobs_pending)
+
     cmd = '/usr/bin/squeue'
     args = ["-h", "--all", "--states=PENDING"]
   
     o, e, s = Open3.capture3({}, cmd, *args)
     
-    s.success? ? o : raise(CommandFailed, e)
+    s.success? ? @squeue_jobs_pending = o : raise(CommandFailed, e)
   end
 
   # Get running jobs
   def squeue_jobs_running
+    return @squeue_jobs_running if defined?(@squeue_jobs_running)
+
     cmd = '/usr/bin/squeue'
     args = ["-h", "--all", "--states=RUNNING"]
   
     o, e, s = Open3.capture3({}, cmd, *args)
     
-    s.success? ? o : raise(CommandFailed, e)
+    s.success? ? @squeue_jobs_running = o : raise(CommandFailed, e)
   end
 
   # Get cluster info (node count, core count, etc.)
   def sinfo
+    return @sinfo if defined?(@sinfo)
+
     cmd = '/usr/bin/sinfo'
     args = ["-s", "-h", "-o=\"%C/%A\""]
   
     o, e, s = Open3.capture3({}, cmd, *args)
     
-    s.success? ? o : raise(CommandFailed, e)
+    s.success? ? @sinfo = o : raise(CommandFailed, e)
   end
   
   def cluster_info

--- a/views/_node_status.erb
+++ b/views/_node_status.erb
@@ -11,6 +11,7 @@
     <%= (showqer.procs_percent).round(2) %>%
   </div>
 </div>
+<% if showqer.job_scheduler_name != "slurm" %>
 <div>
   <span>
     <%= gpustats.total_gpus - gpustats.full_nodes_available %> of <%= gpustats.total_gpus %> GPU Nodes Active (<%= gpustats.full_nodes_available %> Node(s) Free)
@@ -21,10 +22,15 @@
     <%= (gpustats.gpus_percent).round(2) %>%
   </div>
 </div>
+<% end %>
 <hr>
-<div><h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4></div>
-
-
+<div>
+  <% if showqer.cluster_title != "Pitzer Expansion" %>
+    <h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4>
+  <% else %>
+    <h4><%= showqer.available_jobs %> Running or Queued Jobs</h4>
+  <% end %>
+</div>
 <div class="row" style="background-color: #e0f2fa">
   <div class="col-md-2 col-xs-12">
     Running
@@ -50,8 +56,11 @@
         <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= gpustats.percent_of_queued_jobs_not_requesting_gpus(showqer.available_jobs, showqer.eligible_jobs) %>%"></div>
         <div class="progress-bar progress-bar-secondary" role="progressbar" style="width:<%= gpustats.percent_of_queued_jobs_requesting_gpus(showqer.available_jobs) %>%"></div>
       </div>
-      <div class="col-md-6 col-xs-12" style="padding-left: 5px; text-align: left"><span><%= showqer.eligible_jobs %><span class="text-secondary" style="padding-left: 5px;">(<%= gpustats.queued_jobs_requesting_gpus %> requesting GPU)</span></span>
-      </div>
+      <% if showqer.job_scheduler_name != "slurm" %>
+        <div class="col-md-6 col-xs-12" style="padding-left: 5px; text-align: left"><span><%= showqer.eligible_jobs %><span class="text-secondary" style="padding-left: 5px;">(<%= gpustats.queued_jobs_requesting_gpus %> requesting GPU)</span></span></div>
+      <% else %>
+        <div class="col-md-6 col-xs-12" style="padding-left: 5px; text-align: left"><span><%= showqer.eligible_jobs %></div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/views/_node_status.erb
+++ b/views/_node_status.erb
@@ -25,7 +25,7 @@
 <% end %>
 <hr>
 <div>
-  <% if showqer.cluster_title != "Pitzer Expansion" %>
+  <% if showqer.job_scheduler_name != "slurm" %>
     <h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4>
   <% else %>
     <h4><%= showqer.available_jobs %> Running or Queued Jobs</h4>

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,18 +1,17 @@
 <div class="row">
 <!-- node status on /clusters page -->
-<% @clusters.each_with_index do |cluster, index | %>
-      <div class="<%= 'col-sm-offset-3' if index == @clusters.count - 1 && @clusters.count.odd? %> col-sm-6 col-xs-12">
-        <% if cluster.dashboard_url %>
-          <a href = "<%= url(cluster.dashboard_url) %>" target="_blank">
-        <% else %>
-          <a href = "<%= url("/clusters/#{cluster.cluster_id}/hour/report_moab_nodes") %>">
-        <% end %>
-            <div class="panel panel-default bs-callout bs-callout-info text-center panel-clickable">
-              <h4><strong><%= cluster.cluster_title %> Cluster Status</strong></h4>
-              <%= erb :_node_status, :locals => { :showqer => cluster, :gpustats => @gpustats[index].setup } %>
-            </div>
-	      </a>
+  <% @clusters.each_with_index do |cluster, index | %>
+  <div class="<%= 'col-sm-offset-3' if index == @clusters.count - 1 && @clusters.count.odd? %> col-sm-6 col-xs-12">
+    <% if cluster.dashboard_url %>
+      <a href="<%= url(cluster.dashboard_url) %>" target="_blank">
+    <% else %>
+      <a href="<%= url("/clusters/#{cluster.cluster_id}/hour/report_moab_nodes") %>">
+    <% end %>
+      <div class="panel panel-default bs-callout bs-callout-info text-center panel-clickable">
+        <h4><strong><%= cluster.cluster_title %> Cluster Status</strong></h4>
+        <%= erb :_node_status, :locals => { :showqer => cluster, :gpustats => @gpustats[index].setup } %>
       </div>
-<% end %>
+    </a>
+  </div>
+  <% end %>
 </div>
-


### PR DESCRIPTION
This PR adds support for Slurm clusters.

**Notes:**
- For simplicity, `blocked jobs <=> pending jobs`. Slurm has hundreds of reasons a job can be pending, it's out of scope to display that information here. Confirmed with @treydock.
- GPU statistics are WIP.

**Screenshot:**
![1598559571-2020_08_27](https://user-images.githubusercontent.com/6081892/91493705-b1d45b00-e885-11ea-800d-93a4be3d1a85.jpg)
