### PR TITLE
Add GPU statistics for SLURM clusters

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -99,11 +99,6 @@ get '/' do
 end
 
 get '/clusters' do
-  #@clusters = CLUSTERS.map { |cluster| MoabShowqClient.new(cluster).setup }
-  #@error_messages = (@clusters.map{ |cluster| cluster.friendly_error_message}).compact
-  #@gpustats = CLUSTERS.map { |cluster| GPUClusterStatus.new(cluster) }
-  #erb :index
-
   @clusters = CLUSTERS.map { |cluster|
     if cluster.custom_config[:moab]
       MoabShowqClient.new(cluster).setup

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -79,7 +79,7 @@ class SlurmSqueueClient
   def gpu_nodes
     return @available_gpu_nodes if defined?(@available_gpu_nodes)
 
-    Open3.pipeline_rw "sinfo -N -h -a --Format='nodehost,gres:#{@gres_length}'", 'uniq', 'grep gpu:', 'wc -l' do |stdin, stdout|
+    Open3.pipeline_rw "sinfo -N -h -a --Format='nodehost,gres:#{gres_length}'", 'uniq', 'grep gpu:', 'wc -l' do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @available_gpu_nodes = stdout.read.to_i
@@ -92,7 +92,7 @@ class SlurmSqueueClient
   def gpu_nodes_free
     return @gpu_nodes_free if defined?(@gpu_nodes_free)
 
-    Open3.pipeline_rw "sinfo -a -h --Node --Format='nodehost,gres:#{@gres_length}',statelong", 'uniq', 'grep gpu:', 'egrep "idle"', 'wc -l' do |stdin, stdout|
+    Open3.pipeline_rw "sinfo -a -h --Node --Format='nodehost,gres:#{gres_length}',statelong", 'uniq', 'grep gpu:', 'egrep "idle"', 'wc -l' do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @gpu_nodes_free = stdout.read.to_i

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -65,7 +65,7 @@ class SlurmSqueueClient
   # Return length of GRES field from SLURM
   # @return [Integer] gres length
   def gres_length
-    return @gres_length if definde?(@gres_length)
+    return @gres_length if defined?(@gres_length)
 
     Open3.pipeline_rw "sinfo -o '%G' | awk '{ print length }'", "sort -n", "tail -1" do |stdin,stdout|
       stdin.write stdout
@@ -79,7 +79,7 @@ class SlurmSqueueClient
   def gpu_nodes
     return @available_gpu_nodes if defined?(@available_gpu_nodes)
 
-    Open3.pipeline_rw "sinfo -N -h -a --Format='nodehost,gres:#{@gres_length} available'", 'uniq', 'grep gpu:v', 'wc -l' do |stdin, stdout|
+    Open3.pipeline_rw "sinfo -N -h -a --Format='nodehost,gres:#{@gres_length} available'", 'uniq', 'grep gpu:', 'wc -l' do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @available_gpu_nodes = stdout.read.to_i
@@ -92,7 +92,7 @@ class SlurmSqueueClient
   def gpu_nodes_free
     return @gpu_nodes_free if defined?(@gpu_nodes_free)
 
-    Open3.pipeline_rw "sinfo -a -h --states=mixed,idle --Node --Format='nodehost,gres:#{@gres_length}'", 'uniq', 'grep gpu:v', 'wc -l' do |stdin, stdout|
+    Open3.pipeline_rw "sinfo -a -h --states=mixed,idle --Node --Format='nodehost,gres:#{@gres_length}'", 'uniq', 'grep gpu:', 'wc -l' do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @gpu_nodes_free = stdout.read.to_i

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -121,7 +121,7 @@ class SlurmSqueueClient
   def gpu_jobs_pending
     return @gpu_jobs_pending if defined?(@gpu_jobs_pending)
 
-    Open3.pipeline_rw "squeue --states=PENDING -O 'jobid,tres-per-job:100,tres-per-node:100,tres-per-socket:100,tres-per-task:100' -h", "grep gpu", "wc -l" do |stdin, stdout|
+    Open3.pipeline_rw "squeue --states=PENDING -O 'jobid,tres-per-job:#{gres_length},tres-per-node:#{gres_length},tres-per-socket:#{gres_length},tres-per-task:#{gres_length}' -h", "grep gpu", "wc -l" do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @gpu_jobs_pending = stdout.read.to_i

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -79,7 +79,7 @@ class SlurmSqueueClient
   def gpu_nodes_active
     return @gpu_nodes_active if defined?(@gpu_nodes_active)
 
-    Open3.pipeline_rw "sinfo -a -h --states=mixed,allocated --Node --Format='nodehost,gres:100'", 'uniq', 'grep gpu:v', 'wc -l' do |stdin, stdout|
+    Open3.pipeline_rw "sinfo -a -h --states=mixed --Node --Format='nodehost,gres:100'", 'uniq', 'grep gpu:v', 'wc -l' do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @gpu_nodes_active = stdout.read.to_i

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -79,7 +79,7 @@ class SlurmSqueueClient
   def gpu_nodes_active
     return @gpu_nodes_active if defined?(@gpu_nodes_active)
 
-    Open3.pipeline_rw "sinfo -a -h --states=mixed --Node --Format='nodehost,gres:100'", 'uniq', 'grep gpu:v', 'wc -l' do |stdin, stdout|
+    Open3.pipeline_rw "sinfo -a -h --states=mixed,allocated --Node --Format='nodehost,gres:100'", 'uniq', 'grep gpu:v', 'wc -l' do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @gpu_nodes_active = stdout.read.to_i

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -79,7 +79,7 @@ class SlurmSqueueClient
   def gpu_nodes
     return @available_gpu_nodes if defined?(@available_gpu_nodes)
 
-    Open3.pipeline_rw "sinfo -N -h -a --Format='nodehost,gres:#{@gres_length} available'", 'uniq', 'grep gpu:', 'wc -l' do |stdin, stdout|
+    Open3.pipeline_rw "sinfo -N -h -a --Format='nodehost,gres:#{@gres_length}'", 'uniq', 'grep gpu:', 'wc -l' do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @available_gpu_nodes = stdout.read.to_i
@@ -92,7 +92,7 @@ class SlurmSqueueClient
   def gpu_nodes_free
     return @gpu_nodes_free if defined?(@gpu_nodes_free)
 
-    Open3.pipeline_rw "sinfo -a -h --states=mixed,idle --Node --Format='nodehost,gres:#{@gres_length}'", 'uniq', 'grep gpu:', 'wc -l' do |stdin, stdout|
+    Open3.pipeline_rw "sinfo -a -h --Node --Format='nodehost,gres:#{@gres_length}',statelong", 'uniq', 'grep gpu:', 'egrep "idle"', 'wc -l' do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @gpu_nodes_free = stdout.read.to_i
@@ -121,7 +121,7 @@ class SlurmSqueueClient
   def gpu_jobs_pending
     return @gpu_jobs_pending if defined?(@gpu_jobs_pending)
 
-    Open3.pipeline_rw "squeue --states=PENDING -O 'jobid,tres-per-job:#{gres_length},tres-per-node:#{gres_length},tres-per-socket:#{gres_length},tres-per-task:#{gres_length}' -h", "grep gpu", "wc -l" do |stdin, stdout|
+    Open3.pipeline_rw "squeue --states=PENDING -O 'jobid,tres-per-job:#{gres_length},tres-per-node:#{gres_length},tres-per-socket:#{gres_length},tres-per-task:#{gres_length}' -h", "grep gpu:", "wc -l" do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @gpu_jobs_pending = stdout.read.to_i

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -105,7 +105,7 @@ class SlurmSqueueClient
   def gpu_nodes_active
     return @gpu_nodes_active if defined?(@gpu_nodes_active)
 
-    @gpu_nodes_active = @available_gpu_nodes - @gpu_nodes_free
+    @gpu_nodes_active = available_gpu_nodes - gpu_nodes_free
   end
 
   # Returns percentage of GPU nodes that are available

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -67,7 +67,7 @@ class SlurmSqueueClient
   def gpu_nodes
     return @available_gpu_nodes if defined?(@available_gpu_nodes)
 
-    Open3.pipeline_rw "sinfo -N -h --states=allocated,idle --Format='nodehost,gres:100,gresused:100'", 'uniq', 'grep gpu:v', 'wc -l' do |stdin, stdout|
+    Open3.pipeline_rw "sinfo -N -h --states=allocated,idle --Format='nodehost,gres:100'", 'uniq', 'grep gpu:v', 'wc -l' do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @available_gpu_nodes = stdout.read.to_i
@@ -79,7 +79,7 @@ class SlurmSqueueClient
   def gpu_nodes_active
     return @gpu_nodes_active if defined?(@gpu_nodes_active)
 
-    Open3.pipeline_rw "sinfo -a -h --states=mixed --Node --Format='nodehost,gres:100,gresused:100'", 'uniq', 'grep gpu:v', 'wc -l' do |stdin, stdout|
+    Open3.pipeline_rw "sinfo -a -h --states=mixed --Node --Format='nodehost,gres:100'", 'uniq', 'grep gpu:v', 'wc -l' do |stdin, stdout|
       stdin.write stdout
       stdin.close
       @gpu_nodes_active = stdout.read.to_i

--- a/views/_node_status.erb
+++ b/views/_node_status.erb
@@ -14,7 +14,7 @@
 <% if showqer.job_scheduler_name == "slurm" %>
 <div>
   <span>
-    <%= showqer.gpu_nodes_active %> of <%= showqer.gpu_nodes %> GPU Nodes Active (<%= showqer.gpu_nodes - showqer.gpu_nodes_active %> Node(s) Free)
+    <%= (showqer.gpu_nodes - showqer.gpu_nodes_idle) %> of <%= showqer.gpu_nodes %> GPU Nodes Active (<%= showqer.gpu_nodes - showqer.gpu_nodes_idle %> Node(s) Free)
   </span>
 </div>
 <div class="progress">

--- a/views/_node_status.erb
+++ b/views/_node_status.erb
@@ -11,7 +11,18 @@
     <%= (showqer.procs_percent).round(2) %>%
   </div>
 </div>
-<% if showqer.job_scheduler_name != "slurm" %>
+<% if showqer.job_scheduler_name == "slurm" %>
+<div>
+  <span>
+    <%= showqer.gpu_nodes_active %> of <%= showqer.gpu_nodes %> GPU Nodes Active (<%= showqer.gpu_nodes - showqer.gpu_nodes_active %> Node(s) Free)
+  </span>
+</div>
+<div class="progress">
+  <div class="progress-bar progress-bar-secondary" role="progressbar" style="width:<%= showqer.gpu_nodes_available_percent %>%">
+    <%= showqer.gpu_nodes_available_percent.round(2) %>%
+  </div>
+</div>
+<% else %>
 <div>
   <span>
     <%= gpustats.total_gpus - gpustats.full_nodes_available %> of <%= gpustats.total_gpus %> GPU Nodes Active (<%= gpustats.full_nodes_available %> Node(s) Free)
@@ -28,7 +39,7 @@
   <% if showqer.job_scheduler_name != "slurm" %>
     <h4><%= showqer.available_jobs %> Running or Queued Jobs <br><small>(and <%= showqer.blocked_jobs %> blocked jobs)</small></h4>
   <% else %>
-    <h4><%= showqer.available_jobs %> Running or Queued Jobs</h4>
+    <h4><%= showqer.available_jobs %> Running or Queued Jobs <br><br></h4>
   <% end %>
 </div>
 <div class="row" style="background-color: #e0f2fa">
@@ -57,13 +68,13 @@
         <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= gpustats.percent_of_queued_jobs_not_requesting_gpus(showqer.available_jobs, showqer.eligible_jobs) %>%"></div>
         <div class="progress-bar progress-bar-secondary" role="progressbar" style="width:<%= gpustats.percent_of_queued_jobs_requesting_gpus(showqer.available_jobs) %>%"></div>
       <% else %>
-        <div class="progress-bar" role="progressbar" style="width:<%= showqer.eligible_percent %>%"></div>
+        <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= showqer.eligible_percent %>%"></div>
       <% end %>
       </div>
       <% if showqer.job_scheduler_name != "slurm" %>
         <div class="col-md-6 col-xs-12" style="padding-left: 5px; text-align: left"><span><%= showqer.eligible_jobs %><span class="text-secondary" style="padding-left: 5px;">(<%= gpustats.queued_jobs_requesting_gpus %> requesting GPU)</span></span></div>
       <% else %>
-        <div class="col-md-6 col-xs-12" style="padding-left: 5px; text-align: left"><span><%= showqer.eligible_jobs %></div>
+        <div class="col-md-6 col-xs-12" style="padding-left: 5px; text-align: left"><span><%= showqer.eligible_jobs %><span class="text-secondary" style="padding-left: 5px;">(<%= showqer.gpu_jobs_pending %> requesting GPU)</span></span></div>
       <% end %>
     </div>
   </div>

--- a/views/_node_status.erb
+++ b/views/_node_status.erb
@@ -14,7 +14,7 @@
 <% if showqer.job_scheduler_name == "slurm" %>
 <div>
   <span>
-    <%= (showqer.gpu_nodes - showqer.gpu_nodes_idle) %> of <%= showqer.gpu_nodes %> GPU Nodes Active (<%= showqer.gpu_nodes - showqer.gpu_nodes_idle %> Node(s) Free)
+    <%= (showqer.gpu_nodes - showqer.gpu_nodes_free) %> of <%= showqer.gpu_nodes %> GPU Nodes Active (<%= showqer.gpu_nodes_free %> Node(s) Free)
   </span>
 </div>
 <div class="progress">

--- a/views/index.erb
+++ b/views/index.erb
@@ -7,7 +7,7 @@
     <% else %>
       <a href="<%= url("/clusters/#{cluster.cluster_id}/hour/report_moab_nodes") %>">
     <% end %>
-      <div class="panel panel-default bs-callout bs-callout-info text-center panel-clickable <%= 'padding-bottom-95px' if cluster.job_scheduler_name == "slurm" %>">
+      <div class="panel panel-default bs-callout bs-callout-info text-center panel-clickable">
         <h4><strong><%= cluster.cluster_title %> Cluster Status</strong></h4>
         <%= erb :_node_status, :locals => { :showqer => cluster, :gpustats => @gpustats[index].setup } %>
       </div>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -134,7 +134,7 @@
                 <% if cluster.custom_config.key?(:ganglia) %>
                   <a href="<%= url("/clusters/#{cluster.id}/hour/report_moab_nodes") %>"><span><i class="fa fa-chart-area"></i></span>  <%=cluster.metadata.title %> Cluster</a>
                   <%# FIXME: remove duplicate links, instead of the if slurm statement %>
-                <% elsif cluster.custom_config.key?(:grafana) && cluster.job_config && cluster.job_config[:adapter] != "slurm" %>
+                <% elsif cluster.custom_config.key?(:grafana) && cluster.job_config %>
                   <a href="<%= url("/clusters/#{cluster.id}/grafana") %>" target="_blank"><span><i class="fa fa-chart-area"></i></span>  <%=cluster.metadata.title %> Cluster</a>
                 <% end %>
               </li>


### PR DESCRIPTION
* Display number of jobs requesting GPUs.
* Display number of active GPU nodes.
* Display queued jobs graph in the same color as other cluster types do.

**Screenshot:**
![image](https://user-images.githubusercontent.com/6081892/93900954-fe178d00-fcc3-11ea-9485-0959ed4d400b.png)
