### PR TITLE
Only add @canonical_cluster_id if not nil to commands and fix graph UI

### DIFF
--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -111,10 +111,10 @@ class SlurmSqueueClient
   def gpu_nodes
     return @available_gpu_nodes if defined?(@available_gpu_nodes)
 
-    o, e, s = Open3.capture3("#{sinfo_cmd} #{cluster_args} -N -h -a --Format='nodehost,gres:#{gres_length}' | uniq | grep gpu: | wc -l")
+    o, e, s = Open3.capture3("#{sinfo_cmd} #{cluster_args} -N -h -a --Format='nodehost,gres:#{gres_length}'")
 
     if s.success?
-      @available_gpu_nodes = o.to_i
+      @available_gpu_nodes = o.lines.uniq.grep(/gpu:/).count
     else
       # Return stderr as error message
       @error_message = "An error occurred when retrieving available GPU nodes. Exit status #{s.exitstatus}: #{e.to_s}"
@@ -128,10 +128,10 @@ class SlurmSqueueClient
   def gpu_nodes_free
     return @gpu_nodes_free if defined?(@gpu_nodes_free)
 
-    o, e, s = Open3.capture3("#{sinfo_cmd} #{cluster_args} -a -h --Node --Format='nodehost,gres:#{gres_length},statelong' | uniq | grep gpu: | egrep 'idle' | wc -l")
+    o, e, s = Open3.capture3("#{sinfo_cmd} #{cluster_args} -a -h --Node --Format='nodehost,gres:#{gres_length},statelong'")
 
     if s.success?
-      @gpu_nodes_free = o.to_i
+      @gpu_nodes_free = o.lines.uniq.grep(/gpu:/).grep(/idle/).count
     else
       # Return stderr as error message
       @error_message = "An error occurred when retrieving free GPU nodes. Exit status #{s.exitstatus}: #{o.to_s}"
@@ -161,10 +161,10 @@ class SlurmSqueueClient
   def gpu_jobs_pending
     return @gpu_jobs_pending if defined?(@gpu_jobs_pending)
 
-    o, e, s = Open3.capture3("#{squeue_cmd} #{cluster_args} --states=PENDING -O 'jobid,tres-pefr-job:#{gres_length},tres-per-node:#{gres_length},tres-per-socket:#{gres_length},tres-per-task:#{gres_length}' -h | grep gpu: | wc -l")
+    o, e, s = Open3.capture3("#{squeue_cmd} #{cluster_args} --states=PENDING -O 'jobid,tres-pefr-job:#{gres_length},tres-per-node:#{gres_length},tres-per-socket:#{gres_length},tres-per-task:#{gres_length}' -h")
 
     if s.success?
-      @gpu_jobs_pending = o.to_i
+      @gpu_jobs_pending = o.lines.grep(/gpu:/).count
     else
       # Return stderr as error message
       @error_message = "An error occurred when retrieving pending jobs requesting GPUs. Exit status #{s.exitstatus}: #{o.to_s}"

--- a/lib/slurm_squeue_client.rb
+++ b/lib/slurm_squeue_client.rb
@@ -17,7 +17,7 @@ class SlurmSqueueClient
     end
   
     @cluster_id = cluster.id
-    @canonical_cluster_id = @cluster_id.to_s.partition('-').first
+    @canonical_cluster_id = cluster.job_config[:cluster]
     @cluster_title = cluster.metadata.title || cluster.id.titleize
     @job_scheduler = cluster.job_config[:adapter]
 
@@ -138,7 +138,7 @@ class SlurmSqueueClient
   def gpu_jobs_pending
     return @gpu_jobs_pending if defined?(@gpu_jobs_pending)
 
-    o, e, s = Open3.capture3("#{squeue_cmd} --clusters=\"#{@canonical_cluster_id}\" --states=PENDING -O 'jobid,tres-pefr-job:#{gres_length},tres-per-node:#{gres_length},tres-per-socket:#{gres_length},tres-per-task:#{gres_length}' -h | grep gpu: | wc -l")
+    o, e, s = Open3.capture3("#{squeue_cmd} #{ "--clusters=\"#{@canonical_cluster_id}\"" if @canonical_cluster_id } --states=PENDING -O 'jobid,tres-pefr-job:#{gres_length},tres-per-node:#{gres_length},tres-per-socket:#{gres_length},tres-per-task:#{gres_length}' -h | grep gpu: | wc -l")
 
     if s.success?
       @gpu_jobs_pending = o.to_i

--- a/views/_node_status.erb
+++ b/views/_node_status.erb
@@ -69,7 +69,6 @@
         <div class="progress-bar progress-bar-secondary" role="progressbar" style="width:<%= gpustats.percent_of_queued_jobs_requesting_gpus(showqer.available_jobs) %>%"></div>
       <% else %>
         <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= showqer.eligible_percent %>%"></div>
-        <div class="progress-bar progress-bar-secondary" role="progressbar" style="width:<%= showqer.gpu_jobs_pending %>%"></div>
       <% end %>
       </div>
       <% if showqer.job_scheduler_name != "slurm" %>

--- a/views/_node_status.erb
+++ b/views/_node_status.erb
@@ -69,6 +69,7 @@
         <div class="progress-bar progress-bar-secondary" role="progressbar" style="width:<%= gpustats.percent_of_queued_jobs_requesting_gpus(showqer.available_jobs) %>%"></div>
       <% else %>
         <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= showqer.eligible_percent %>%"></div>
+        <div class="progress-bar progress-bar-secondary" role="progressbar" style="width:<%= showqer.gpu_jobs_pending %>%"></div>
       <% end %>
       </div>
       <% if showqer.job_scheduler_name != "slurm" %>


### PR DESCRIPTION
**Overview:**
- Only add @canonical_cluster_id if not nil to commands.

This PR fixes #97.

We can convert some functions using `capture3` to `pipeline_rw` that results in cleaner code:
```ruby
args = []
args.push("--clusters=\"#{@canonical_cluster_id}\"") if defined?(@canonical_cluster_id)

Open3.pipeline_rw([sinfo_cmd, *args], "wc -l", "uniq", "grep gpu:", "egrep idle", "wc -l") {|i, o, wait_threads|
  puts o.read
}
```

Instead of how it's currently done:
```ruby
o, e, s = Open3.capture3("#{sinfo_cmd} #{ "--clusters=\"#{@canonical_cluster_id}\"" if defined?(@canonical_cluster_id) } -N -h -a --Format='nodehost,gres:#{gres_length}' | uniq | grep gpu: | wc -l")

if s.success?
  @available_gpu_nodes = o.to_i
else
  # Return stderr as error message
  @error_message = "An error occurred when retrieving available GPU nodes. Exit status #{s.exitstatus}: #{e.to_s}"
  0
end
```

It's not clear how to implement the same level of error checking though. Food for thought.