### PR TITLE
Fix missing secondary bar on GPU graphs

### DIFF
--- a/views/_node_status.erb
+++ b/views/_node_status.erb
@@ -69,6 +69,7 @@
         <div class="progress-bar progress-bar-secondary" role="progressbar" style="width:<%= gpustats.percent_of_queued_jobs_requesting_gpus(showqer.available_jobs) %>%"></div>
       <% else %>
         <div class="progress-bar progress-bar-info" role="progressbar" style="width:<%= showqer.eligible_percent %>%"></div>
+        <div class="progress-bar progress-bar-secondary" role="progressbar" style="width:<%= showqer.gpu_jobs_pending %>%"></div>
       <% end %>
       </div>
       <% if showqer.job_scheduler_name != "slurm" %>


### PR DESCRIPTION
This PR adds back the orange secondary bar indicating the number of pending jobs requesting GPUs.

**Screenshots**

Fixed
<img src="https://user-images.githubusercontent.com/6081892/100176195-d6000200-2e9d-11eb-9f05-9edf605a8145.png" width=500>

vs the old verison:

<img src="https://user-images.githubusercontent.com/6081892/100176288-fcbe3880-2e9d-11eb-92fa-b6fb0cfef8af.png" width=500>