### PR TITLE
account for clusters being nil

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -98,20 +98,22 @@ get '/' do
 end
 
 get '/clusters' do
-  @clusters = CLUSTERS.map { |cluster|
+  @clusters = CLUSTERS.map do |cluster|
     if cluster.custom_config[:moab]
       MoabShowqClient.new(cluster).setup
     else
       SlurmSqueueClient.new(cluster).setup
     end
-  }
-  @gpustats = CLUSTERS.map { |cluster|
+  end.compact
+
+  @gpustats = CLUSTERS.map do |cluster|
     if cluster.custom_config[:moab]
       GPUClusterStatus.new(cluster)
     else
       GPUClusterStatusSlurm.new(cluster)
     end
-  }
+  end.compact
+
   @error_messages = (@clusters.map{ |cluster| cluster.friendly_error_message}).compact
 
   erb :index


### PR DESCRIPTION
production - as well as other environments - are currently failing here with 

```
undefined method `friendly_error_message' for nil:NilClass
```

Somehow owens is not populating correctly and it's returning `nil` in this @clusters object.